### PR TITLE
Added namespace declaration for branding namespace

### DIFF
--- a/js/controllers/stixForms.js
+++ b/js/controllers/stixForms.js
@@ -228,6 +228,7 @@ function ttFormCntrl($scope, $http, $compile, $filter) {
             "<stix:STIX_Package" +
             "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
             "    xmlns:stix=\"http://stix.mitre.org/stix-1\"" +
+            "    xmlns:{{branding}}=\"{{brandingNamespace}}\"" +
             "    id=\"{{branding}}:STIXPackage-{{UUID}}\"";
 
 
@@ -239,6 +240,7 @@ function ttFormCntrl($scope, $http, $compile, $filter) {
 
     $scope.creationTimestamp = Date.now();
     $scope.branding = "ttDemo";
+    $scope.brandingNamespace = "ttDemo";
 
 
     // ADDERS
@@ -317,6 +319,7 @@ function ttFormCntrl($scope, $http, $compile, $filter) {
                 'xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"' + '\n' +
                 'xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"' + '\n' +
                 'xmlns:ttp="http://stix.mitre.org/TTP-1"' + '\n' +
+                'xmlns:ttDemo="ttDemo"' + '\n' + 
                 'xsi:schemaLocation="' + '\n' +
                 '\thttp://stix.mitre.org/stix-1 ../stix_core.xsd' + '\n' +
                 '\thttp://stix.mitre.org/Indicator-2 ../indicator.xsd' + '\n' +

--- a/templates/xmlBodies/Courses of Action.xml
+++ b/templates/xmlBodies/Courses of Action.xml
@@ -9,6 +9,7 @@
         xmlns:cyboxCommon="http://cybox.mitre.org/common-2"        
         xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
         xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
+        xmlns:{{$parent.branding}}="{{$parent.brandingNamespace}}"
         xsi:schemaLocation="
             http://stix.mitre.org/stix-1 ../stix_core.xsd
             http://stix.mitre.org/Indicator-2 ../indicator.xsd

--- a/templates/xmlBodies/IP Watchlist.xml
+++ b/templates/xmlBodies/IP Watchlist.xml
@@ -9,6 +9,7 @@
         xmlns:cyboxCommon="http://cybox.mitre.org/common-2"        
         xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
         xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
+        xmlns:{{$parent.branding}}="{{$parent.brandingNamespace}}"
         xsi:schemaLocation="
             http://stix.mitre.org/stix-1 ../stix_core.xsd
             http://stix.mitre.org/Indicator-2 ../indicator.xsd

--- a/templates/xmlBodies/Indicators.xml
+++ b/templates/xmlBodies/Indicators.xml
@@ -9,6 +9,7 @@
         xmlns:cyboxCommon="http://cybox.mitre.org/common-2"        
         xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
         xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
+        xmlns:{{$parent.branding}}="{{$parent.branding}}"
         xsi:schemaLocation="
             http://stix.mitre.org/stix-1 ../stix_core.xsd
             http://stix.mitre.org/Indicator-2 ../indicator.xsd

--- a/templates/xmlBodies/Malware Samples.xml
+++ b/templates/xmlBodies/Malware Samples.xml
@@ -8,7 +8,8 @@
     xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
     xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
     xmlns:stixCommon="http://stix.mitre.org/common-1"
-    xmlns:cyboxCommon="http://cybox.mitre.org/common-2"        
+    xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
+    xmlns:{{$parent.branding}}="{{$parent.brandingNamespace}}"        
     xsi:schemaLocation=
     "http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.0.1/stix_core.xsd
     http://cybox.mitre.org/objects#FileObject-2 http://cybox.mitre.org/XMLSchema/objects/File/2.0.1/File_Object.xsd


### PR DESCRIPTION
I added some code to add the namespace declaration for the $branding namespace prefix that is used for IDs. This will clear up validation errors against STIX 1.0.1 related to that namespace being undefined.

I create a new variable called "brandingNamespace" to hold the namespace itself but for now just set it to "ttDemo", same as branding.
