### PR TITLE
Fix validation issue in STIX_Header

### DIFF
--- a/js/controllers/stixForms.js
+++ b/js/controllers/stixForms.js
@@ -334,9 +334,11 @@ function ttFormCntrl($scope, $http, $compile, $filter) {
         header = '<stix:STIX_Header>' +
                 '<stix:Title>' + $scope.stixPackageTitle + '</stix:Title>' +
                 '<stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">' + $scope.packageIntent.value + '</stix:Package_Intent>' +
+                '<stix:Information_Source>' + 
                 '<stixCommon:Time>' +
                 '<cyboxCommon:Produced_Time>' + $filter('date')($scope.creationTimestamp, 'yyyy-MM-ddTHH:mm:ssZ') + '</cyboxCommon:Produced_Time>' +
                 '</stixCommon:Time>' +
+                '</stix:Information_Source>' + 
                 '</stix:STIX_Header>';
         return header;
     };

--- a/templates/xmlBodies/Courses of Action.xml
+++ b/templates/xmlBodies/Courses of Action.xml
@@ -23,9 +23,11 @@
         <stix:STIX_Header>
             <stix:Title>{{$parent.stixPackageTitle}}</stix:Title>
             <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">{{$parent.packageIntent.value}}</stix:Package_Intent>
-            <stixCommon:Time>
-                <cyboxCommon:Produced_Time>{{$parent.creationTimestamp| date:'yyyy-MM-ddTHH:mm:ssZ'}}</cyboxCommon:Produced_Time>
-            </stixCommon:Time>        
+            <stix:Information_Source>
+                <stixCommon:Time>
+                    <cyboxCommon:Produced_Time>{{$parent.creationTimestamp| date:'yyyy-MM-ddTHH:mm:ssZ'}}</cyboxCommon:Produced_Time>
+                </stixCommon:Time>        
+            </stix:Information_Source>
         </stix:STIX_Header>
 {{$parent.printGeneric(COAs)}}
     </stix:STIX_Package>

--- a/templates/xmlBodies/IP Watchlist.xml
+++ b/templates/xmlBodies/IP Watchlist.xml
@@ -23,9 +23,11 @@
         <stix:STIX_Header>
             <stix:Title>{{$parent.stixPackageTitle}}</stix:Title>
             <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">{{$parent.packageIntent.value}}</stix:Package_Intent>
-            <stixCommon:Time>
-                <cyboxCommon:Produced_Time>{{$parent.creationTimestamp| date:'yyyy-MM-ddTHH:mm:ssZ'}}</cyboxCommon:Produced_Time>
-            </stixCommon:Time>        
+            <stix:Information_Source>
+                <stixCommon:Time>
+                    <cyboxCommon:Produced_Time>{{$parent.creationTimestamp| date:'yyyy-MM-ddTHH:mm:ssZ'}}</cyboxCommon:Produced_Time>
+                </stixCommon:Time>        
+            </stix:Information_Source>        
         </stix:STIX_Header>
         <stix:Indicators>
             <stix:Indicator xsi:type="indicator:IndicatorType" id="{{$parent.branding}}:Indicator-{{$parent.newUUID3}}">

--- a/templates/xmlBodies/Indicators.xml
+++ b/templates/xmlBodies/Indicators.xml
@@ -23,9 +23,11 @@
         <stix:STIX_Header>
             <stix:Title>{{$parent.stixPackageTitle}}</stix:Title>
             <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">{{$parent.packageIntent.value}}</stix:Package_Intent>
-            <stixCommon:Time>
-                <cyboxCommon:Produced_Time>{{$parent.creationTimestamp| date:'yyyy-MM-ddTHH:mm:ssZ'}}</cyboxCommon:Produced_Time>
-            </stixCommon:Time>        
+            <stix:Information_Source>
+                <stixCommon:Time>
+                    <cyboxCommon:Produced_Time>{{$parent.creationTimestamp| date:'yyyy-MM-ddTHH:mm:ssZ'}}</cyboxCommon:Produced_Time>
+                </stixCommon:Time>        
+            </stix:Information_Source>
         </stix:STIX_Header>
         <stix:Indicators>
             <stix:Indicator xsi:type="indicator:IndicatorType" id="{{$parent.branding}}:Indicator-{{$parent.newUUID3}}">

--- a/templates/xmlBodies/Malware Samples.xml
+++ b/templates/xmlBodies/Malware Samples.xml
@@ -22,9 +22,11 @@
         <stix:Title>{{$parent.stixPackageTitle}}</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">{{$parent.packageIntent.value}}</stix:Package_Intent>
         <stix:Description>{{$parent.stixDescription}}</stix:Description>
-        <stixCommon:Time>
+        <stix:Information_Source>
+            <stixCommon:Time>
                 <cyboxCommon:Produced_Time>{{$parent.creationTimestamp| date:'yyyy-MM-ddTHH:mm:ssZ'}}</cyboxCommon:Produced_Time>
-        </stixCommon:Time>        
+            </stixCommon:Time>        
+        </stix:Information_Source>       
     </stix:STIX_Header>
     <stix:Observables cybox_major_version="2" cybox_minor_version="0" cybox_update_version="1">
         <cybox:Observable id="{{$parent.branding}}:Observable-{{$parent.newUUID}}">


### PR DESCRIPTION
In the old code, the stixCommon:Time element was directly under STIX_Header. Instead, it needs to be nested under stix:Information_Source in order to be valid.

There's unfortunately still a validation issue in the time code, however. The timezone offset is being formatted incorrectly per the XML spec and so even with this fix unless you happen to be UTC the document will still not be valid STIX. I'll submit an issue for this, it's beyond my javascript abilities to fix it myself, sorry.
